### PR TITLE
Add GitHub Actions workflow to build the MFC app on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,15 +38,7 @@ jobs:
         run: |
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86 -host_arch=x64
           if errorlevel 1 exit /b 1
-          echo VCINSTALLDIR=%VCINSTALLDIR%
           for /f "delims=" %%i in ('dir /b "%VCINSTALLDIR%Tools\MSVC"') do set VCTOOLSVER=%%i
-          echo VCTOOLSVER=%VCTOOLSVER%
-          dir "%VCINSTALLDIR%Tools\MSVC\%VCTOOLSVER%\atlmfc\lib\x86\mfc140.lib"
-          echo ---- looking for cl.exe ----
-          dir /s /b "%VCINSTALLDIR%Tools\MSVC\%VCTOOLSVER%\bin\cl.exe"
-          echo ---- PATH ----
-          echo %PATH%
-          where cl.exe
           msbuild wfgui.vcxproj /p:Configuration=Release /p:Platform=Win32 /p:PlatformToolset=v143 /p:VCToolsVersion=%VCTOOLSVER% /p:WindowsTargetPlatformVersion=10.0 /m
 
       - name: Upload build artifact

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,42 +32,13 @@ jobs:
             throw "vs_buildtools.exe failed with exit code $($proc.ExitCode)"
           }
 
-      - name: Diagnose install (non-blocking)
-        shell: pwsh
-        run: |
-          $msvcRoot = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
-          if (Test-Path $msvcRoot) {
-            Get-ChildItem $msvcRoot -Directory | ForEach-Object {
-              $atlmfc = Join-Path $_.FullName "atlmfc"
-              Write-Host "$($_.FullName) -> atlmfc present: $(Test-Path $atlmfc)"
-            }
-          } else {
-            Write-Host "MSVC root not found at $msvcRoot"
-          }
-
-          Write-Host "==== bootstrapper default logs (%TEMP%\dd_*.log) ===="
-          Get-ChildItem -Path "$env:TEMP\dd_*.log" -ErrorAction SilentlyContinue | ForEach-Object {
-            Write-Host "---- $($_.FullName) ----"
-            Get-Content $_.FullName -Tail 150
-          }
-
-      - name: Locate MSBuild
-        id: msbuild
-        shell: pwsh
-        run: |
-          $msbuild = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" -ErrorAction Stop
-          Write-Host "Found: $($msbuild.FullName)"
-          "path=$($msbuild.FullName)" >> $env:GITHUB_OUTPUT
-
       - name: Build (Release|Win32)
-        shell: pwsh
-        run: >
-          & "${{ steps.msbuild.outputs.path }}" wfgui.vcxproj
-          /p:Configuration=Release
-          /p:Platform=Win32
-          /p:PlatformToolset=v143
-          /p:WindowsTargetPlatformVersion=10.0
-          /m
+        shell: cmd
+        run: |
+          call "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86 -host_arch=x64
+          if errorlevel 1 exit /b 1
+          echo VCINSTALLDIR=%VCINSTALLDIR%
+          msbuild wfgui.vcxproj /p:Configuration=Release /p:Platform=Win32 /p:PlatformToolset=v143 /p:WindowsTargetPlatformVersion=10.0 /m
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,10 +24,10 @@ jobs:
 
           Write-Host "Modifying VS install at $vsPath (log: $logFile)"
           $proc = Start-Process -FilePath $installer -ArgumentList @(
-            "modify", "--installPath", "`"$vsPath`"",
+            "modify", "--installPath", $vsPath,
             "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
             "--quiet", "--norestart", "--wait",
-            "--log", "`"$logFile`""
+            "--log", $logFile
           ) -Wait -NoNewWindow -PassThru
 
           Write-Host "vs_installer exit code: $($proc.ExitCode)"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,51 +14,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install MFC/ATL build component
+      - name: Install VS Build Tools (VC++ + MFC/ATL)
         shell: pwsh
         run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsPath = & $vswhere -latest -products * -property installationPath
-          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
-          $logFile = "$env:RUNNER_TEMP\vs_modify.log"
-          $stdOut = "$env:RUNNER_TEMP\vs_modify_stdout.log"
-          $stdErr = "$env:RUNNER_TEMP\vs_modify_stderr.log"
+          $exe = "$env:RUNNER_TEMP\vs_buildtools.exe"
+          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile $exe -UseBasicParsing
 
-          Write-Host "vswhere: $vswhere"
-          Write-Host "installer: $installer"
-          Write-Host "vsPath: [$vsPath]"
-          Write-Host "Modifying VS install at $vsPath (log: $logFile)"
-
-          $proc = Start-Process -FilePath $installer -ArgumentList @(
-            "modify", "--installPath", $vsPath,
-            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
-            "--quiet", "--norestart", "--wait",
-            "--log", $logFile
-          ) -Wait -NoNewWindow -PassThru `
-            -RedirectStandardOutput $stdOut -RedirectStandardError $stdErr
-
-          Write-Host "vs_installer exit code: $($proc.ExitCode)"
-          Write-Host "---- stdout ----"
-          if (Test-Path $stdOut) { Get-Content $stdOut }
-          Write-Host "---- stderr ----"
-          if (Test-Path $stdErr) { Get-Content $stdErr }
-          Write-Host "---- install log ----"
-          if (Test-Path $logFile) { Get-Content $logFile -Tail 300 } else { Write-Host "(no log file at $logFile)" }
-
+          $args = @(
+            "--quiet", "--wait", "--norestart", "--nocache",
+            "--add", "Microsoft.VisualStudio.Workload.VCTools",
+            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC"
+          )
+          $proc = Start-Process -FilePath $exe -ArgumentList $args -Wait -PassThru
+          Write-Host "vs_buildtools exit code: $($proc.ExitCode)"
           # 3010 = success, reboot required (fine under --norestart in CI)
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
-            throw "vs_installer modify failed with exit code $($proc.ExitCode)"
+            throw "vs_buildtools.exe failed with exit code $($proc.ExitCode)"
           }
 
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+      - name: Locate MSBuild
+        id: msbuild
+        shell: pwsh
+        run: |
+          $msbuild = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" -ErrorAction Stop
+          Write-Host "Found: $($msbuild.FullName)"
+          "path=$($msbuild.FullName)" >> $env:GITHUB_OUTPUT
 
       - name: Build (Release|Win32)
         run: >
-          msbuild wfgui.vcxproj
+          "${{ steps.msbuild.outputs.path }}" wfgui.vcxproj
           /p:Configuration=Release
           /p:Platform=Win32
-          /p:PlatformToolset=v143
           /p:WindowsTargetPlatformVersion=10.0
           /m
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,22 +14,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Ensure MFC/ATL build component is installed
+      - name: Install MFC/ATL build component
         shell: pwsh
         run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $vsPath = & $vswhere -latest -products * -property installationPath
-          $hasMfc = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.ATLMFC -property installationPath
-          if (-not $hasMfc) {
-            Write-Host "Installing MFC/ATL component into $vsPath"
-            $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
-            Start-Process -FilePath $installer -ArgumentList @(
-              "modify", "--installPath", "`"$vsPath`"",
-              "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
-              "--quiet", "--norestart", "--wait"
-            ) -Wait -NoNewWindow
-          } else {
-            Write-Host "MFC/ATL component already present."
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+          $logFile = "$env:RUNNER_TEMP\vs_modify.log"
+
+          Write-Host "Modifying VS install at $vsPath (log: $logFile)"
+          $proc = Start-Process -FilePath $installer -ArgumentList @(
+            "modify", "--installPath", "`"$vsPath`"",
+            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
+            "--quiet", "--norestart", "--wait",
+            "--log", "`"$logFile`""
+          ) -Wait -NoNewWindow -PassThru
+
+          Write-Host "vs_installer exit code: $($proc.ExitCode)"
+          # 3010 = success, reboot required (fine under --norestart in CI)
+          if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+            if (Test-Path $logFile) { Get-Content $logFile -Tail 300 }
+            throw "vs_installer modify failed with exit code $($proc.ExitCode)"
           }
 
       - name: Add MSBuild to PATH

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,42 +18,37 @@ jobs:
         shell: pwsh
         run: |
           $exe = "$env:RUNNER_TEMP\vs_buildtools.exe"
-          $logFile = "$env:RUNNER_TEMP\vs_buildtools_install.log"
           Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile $exe -UseBasicParsing
 
           $args = @(
             "--quiet", "--wait", "--norestart", "--nocache",
-            "--log", $logFile,
             "--add", "Microsoft.VisualStudio.Workload.VCTools",
-            "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
-            "--includeRecommended"
+            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC"
           )
           $proc = Start-Process -FilePath $exe -ArgumentList $args -Wait -PassThru
           Write-Host "vs_buildtools exit code: $($proc.ExitCode)"
           # 3010 = success, reboot required (fine under --norestart in CI)
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
-            if (Test-Path $logFile) { Get-Content $logFile -Tail 300 }
             throw "vs_buildtools.exe failed with exit code $($proc.ExitCode)"
           }
 
+      - name: Diagnose install (non-blocking)
+        shell: pwsh
+        run: |
           $msvcRoot = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
-          $found = $false
           if (Test-Path $msvcRoot) {
             Get-ChildItem $msvcRoot -Directory | ForEach-Object {
               $atlmfc = Join-Path $_.FullName "atlmfc"
-              $exists = Test-Path $atlmfc
-              Write-Host "$($_.FullName) -> atlmfc present: $exists"
-              if ($exists) { $found = $true }
+              Write-Host "$($_.FullName) -> atlmfc present: $(Test-Path $atlmfc)"
             }
           } else {
             Write-Host "MSVC root not found at $msvcRoot"
           }
 
-          if (-not $found) {
-            Write-Host "==== install log tail ===="
-            if (Test-Path $logFile) { Get-Content $logFile -Tail 400 } else { Write-Host "(no log at $logFile)" }
-            throw "ATLMFC libraries were not found under any MSVC toolset after install."
+          Write-Host "==== bootstrapper default logs (%TEMP%\dd_*.log) ===="
+          Get-ChildItem -Path "$env:TEMP\dd_*.log" -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host "---- $($_.FullName) ----"
+            Get-Content $_.FullName -Tail 150
           }
 
       - name: Locate MSBuild

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,52 @@
+name: Build (Windows / MFC)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure MFC/ATL build component is installed
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -property installationPath
+          $hasMfc = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.ATLMFC -property installationPath
+          if (-not $hasMfc) {
+            Write-Host "Installing MFC/ATL component into $vsPath"
+            $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+            Start-Process -FilePath $installer -ArgumentList @(
+              "modify", "--installPath", "`"$vsPath`"",
+              "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
+              "--quiet", "--norestart", "--wait"
+            ) -Wait -NoNewWindow
+          } else {
+            Write-Host "MFC/ATL component already present."
+          }
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build (Release|Win32)
+        run: >
+          msbuild wfgui.vcxproj
+          /p:Configuration=Release
+          /p:Platform=Win32
+          /p:PlatformToolset=v143
+          /p:WindowsTargetPlatformVersion=10.0
+          /m
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wfgui-release-win32
+          path: Release/*.exe
+          if-no-files-found: error

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -41,6 +41,11 @@ jobs:
           for /f "delims=" %%i in ('dir /b "%VCINSTALLDIR%Tools\MSVC"') do set VCTOOLSVER=%%i
           echo VCTOOLSVER=%VCTOOLSVER%
           dir "%VCINSTALLDIR%Tools\MSVC\%VCTOOLSVER%\atlmfc\lib\x86\mfc140.lib"
+          echo ---- looking for cl.exe ----
+          dir /s /b "%VCINSTALLDIR%Tools\MSVC\%VCTOOLSVER%\bin\cl.exe"
+          echo ---- PATH ----
+          echo %PATH%
+          where cl.exe
           msbuild wfgui.vcxproj /p:Configuration=Release /p:Platform=Win32 /p:PlatformToolset=v143 /p:VCToolsVersion=%VCTOOLSVER% /p:WindowsTargetPlatformVersion=10.0 /m
 
       - name: Upload build artifact

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,7 +38,10 @@ jobs:
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86 -host_arch=x64
           if errorlevel 1 exit /b 1
           echo VCINSTALLDIR=%VCINSTALLDIR%
-          msbuild wfgui.vcxproj /p:Configuration=Release /p:Platform=Win32 /p:PlatformToolset=v143 /p:WindowsTargetPlatformVersion=10.0 /m
+          for /f "delims=" %%i in ('dir /b "%VCINSTALLDIR%Tools\MSVC"') do set VCTOOLSVER=%%i
+          echo VCTOOLSVER=%VCTOOLSVER%
+          dir "%VCINSTALLDIR%Tools\MSVC\%VCTOOLSVER%\atlmfc\lib\x86\mfc140.lib"
+          msbuild wfgui.vcxproj /p:Configuration=Release /p:Platform=Win32 /p:PlatformToolset=v143 /p:VCToolsVersion=%VCTOOLSVER% /p:WindowsTargetPlatformVersion=10.0 /m
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,8 +3,12 @@ name: Build (Windows / MFC)
 on:
   push:
     branches: [ master ]
+    tags: [ 'v*' ]
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -47,3 +51,9 @@ jobs:
           name: wfgui-release-win32
           path: Release/*.exe
           if-no-files-found: error
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Release/*.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,6 +23,7 @@ jobs:
           $args = @(
             "--quiet", "--wait", "--norestart", "--nocache",
             "--add", "Microsoft.VisualStudio.Workload.VCTools",
+            "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
             "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC"
           )
           $proc = Start-Process -FilePath $exe -ArgumentList $args -Wait -PassThru

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,19 +21,32 @@ jobs:
           $vsPath = & $vswhere -latest -products * -property installationPath
           $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
           $logFile = "$env:RUNNER_TEMP\vs_modify.log"
+          $stdOut = "$env:RUNNER_TEMP\vs_modify_stdout.log"
+          $stdErr = "$env:RUNNER_TEMP\vs_modify_stderr.log"
 
+          Write-Host "vswhere: $vswhere"
+          Write-Host "installer: $installer"
+          Write-Host "vsPath: [$vsPath]"
           Write-Host "Modifying VS install at $vsPath (log: $logFile)"
+
           $proc = Start-Process -FilePath $installer -ArgumentList @(
             "modify", "--installPath", $vsPath,
             "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
             "--quiet", "--norestart", "--wait",
             "--log", $logFile
-          ) -Wait -NoNewWindow -PassThru
+          ) -Wait -NoNewWindow -PassThru `
+            -RedirectStandardOutput $stdOut -RedirectStandardError $stdErr
 
           Write-Host "vs_installer exit code: $($proc.ExitCode)"
+          Write-Host "---- stdout ----"
+          if (Test-Path $stdOut) { Get-Content $stdOut }
+          Write-Host "---- stderr ----"
+          if (Test-Path $stdErr) { Get-Content $stdErr }
+          Write-Host "---- install log ----"
+          if (Test-Path $logFile) { Get-Content $logFile -Tail 300 } else { Write-Host "(no log file at $logFile)" }
+
           # 3010 = success, reboot required (fine under --norestart in CI)
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
-            if (Test-Path $logFile) { Get-Content $logFile -Tail 300 }
             throw "vs_installer modify failed with exit code $($proc.ExitCode)"
           }
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,18 +18,42 @@ jobs:
         shell: pwsh
         run: |
           $exe = "$env:RUNNER_TEMP\vs_buildtools.exe"
+          $logFile = "$env:RUNNER_TEMP\vs_buildtools_install.log"
           Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile $exe -UseBasicParsing
 
           $args = @(
             "--quiet", "--wait", "--norestart", "--nocache",
+            "--log", $logFile,
             "--add", "Microsoft.VisualStudio.Workload.VCTools",
-            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC"
+            "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
+            "--includeRecommended"
           )
           $proc = Start-Process -FilePath $exe -ArgumentList $args -Wait -PassThru
           Write-Host "vs_buildtools exit code: $($proc.ExitCode)"
           # 3010 = success, reboot required (fine under --norestart in CI)
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+            if (Test-Path $logFile) { Get-Content $logFile -Tail 300 }
             throw "vs_buildtools.exe failed with exit code $($proc.ExitCode)"
+          }
+
+          $msvcRoot = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
+          $found = $false
+          if (Test-Path $msvcRoot) {
+            Get-ChildItem $msvcRoot -Directory | ForEach-Object {
+              $atlmfc = Join-Path $_.FullName "atlmfc"
+              $exists = Test-Path $atlmfc
+              Write-Host "$($_.FullName) -> atlmfc present: $exists"
+              if ($exists) { $found = $true }
+            }
+          } else {
+            Write-Host "MSVC root not found at $msvcRoot"
+          }
+
+          if (-not $found) {
+            Write-Host "==== install log tail ===="
+            if (Test-Path $logFile) { Get-Content $logFile -Tail 400 } else { Write-Host "(no log at $logFile)" }
+            throw "ATLMFC libraries were not found under any MSVC toolset after install."
           }
 
       - name: Locate MSBuild

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,6 +45,25 @@ jobs:
           for /f "delims=" %%i in ('dir /b "%VCINSTALLDIR%Tools\MSVC"') do set VCTOOLSVER=%%i
           msbuild wfgui.vcxproj /p:Configuration=Release /p:Platform=Win32 /p:PlatformToolset=v143 /p:VCToolsVersion=%VCTOOLSVER% /p:WindowsTargetPlatformVersion=10.0 /m
 
+      - name: Set version
+        id: version
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -like 'refs/tags/*') {
+            $ver = $env:GITHUB_REF -replace 'refs/tags/', ''
+          } else {
+            $ver = $env:GITHUB_SHA.Substring(0, 7)
+          }
+          echo "version=$ver" >> $env:GITHUB_OUTPUT
+
+      - name: Rename binary with version
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path Release -Filter *.exe | Select-Object -First 1
+          $newName = "$($exe.BaseName)-${{ steps.version.outputs.version }}$($exe.Extension)"
+          Rename-Item -Path $exe.FullName -NewName $newName
+          Write-Host "Renamed to $newName"
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,6 +46,7 @@ jobs:
           & "${{ steps.msbuild.outputs.path }}" wfgui.vcxproj
           /p:Configuration=Release
           /p:Platform=Win32
+          /p:PlatformToolset=v143
           /p:WindowsTargetPlatformVersion=10.0
           /m
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -41,8 +41,9 @@ jobs:
           "path=$($msbuild.FullName)" >> $env:GITHUB_OUTPUT
 
       - name: Build (Release|Win32)
+        shell: pwsh
         run: >
-          "${{ steps.msbuild.outputs.path }}" wfgui.vcxproj
+          & "${{ steps.msbuild.outputs.path }}" wfgui.vcxproj
           /p:Configuration=Release
           /p:Platform=Win32
           /p:WindowsTargetPlatformVersion=10.0

--- a/3DMeterCtrl.cpp
+++ b/3DMeterCtrl.cpp
@@ -57,7 +57,7 @@ void C3DMeterCtrl::OnPaint()
 	GetClientRect (&m_rectCtrl) ;
 
 	// make a memory dc
-	CMemDC memDC(&dc, &m_rectCtrl);
+	CMemDCLocal memDC(&dc, &m_rectCtrl);
 
 	// set up a memory dc for the background stuff 
 	// if one isn't being used

--- a/MemDC.h
+++ b/MemDC.h
@@ -37,7 +37,7 @@
 // This class implements a memory Device Context which allows
 // flicker free drawing.
 
-class CMemDC : public CDC 
+class CMemDCLocal : public CDC
 {
 private:	
 	CBitmap		m_bitmap;		// Offscreen bitmap
@@ -47,7 +47,7 @@ private:
 	BOOL		m_bMemDC;		// TRUE if CDC really is a Memory DC.
 public:
 	
-	CMemDC(CDC* pDC, const CRect* pRect = NULL, bool boolToMemory = TRUE) : CDC()
+	CMemDCLocal(CDC* pDC, const CRect* pRect = NULL, bool boolToMemory = TRUE) : CDC()
 	{
 		ASSERT(pDC != NULL); 
 
@@ -96,34 +96,34 @@ public:
 	}
 
 	
-	~CMemDC()	
-	{		
-		if (m_bMemDC) 
+	~CMemDCLocal()
+	{
+		if (m_bMemDC)
 		{
 			// Copy the offscreen bitmap onto the screen.
 			m_pDC->BitBlt(m_rect.left, m_rect.top, m_rect.Width(), m_rect.Height(),
-				            this, m_rect.left, m_rect.top, SRCCOPY);			
-			
+				            this, m_rect.left, m_rect.top, SRCCOPY);
+
 			//Swap back the original bitmap.
 			SelectObject(m_oldBitmap);
-		} 
-		else 
+		}
+		else
 		{
 			// All we need to do is replace the DC with an illegal value,
 			// this keeps us from accidently deleting the handles associated with
-			// the CDC that was passed to the constructor.			
+			// the CDC that was passed to the constructor.
 			m_hDC = m_hAttribDC = NULL;
-		}	
+		}
 	}
-	
-	// Allow usage as a pointer	
-	CMemDC* operator->() 
+
+	// Allow usage as a pointer
+	CMemDCLocal* operator->()
 	{
 		return this;
-	}	
+	}
 
-	// Allow usage as a pointer	
-	operator CMemDC*() 
+	// Allow usage as a pointer
+	operator CMemDCLocal*()
 	{
 		return this;
 	}

--- a/MemoryDC.h
+++ b/MemoryDC.h
@@ -26,7 +26,7 @@
 // This class implements a memory Device Context which allows
 // flicker free drawing.
 
-class CMemDC : public CDC {
+class CMemDCLocal : public CDC {
 private:	
 	CBitmap		m_bitmap;		// Offscreen bitmap
 	CBitmap*	m_oldBitmap;	// bitmap originally found in CMemDC
@@ -35,7 +35,7 @@ private:
 	BOOL		m_bMemDC;		// TRUE if CDC really is a Memory DC.
 public:
 	
-	CMemDC(CDC* pDC, const CRect* pRect = NULL) : CDC()
+	CMemDCLocal(CDC* pDC, const CRect* pRect = NULL) : CDC()
 	{
 		ASSERT(pDC != NULL); 
 
@@ -77,31 +77,31 @@ public:
 		FillSolidRect(m_rect, pDC->GetBkColor());
 	}
 	
-	~CMemDC()	
-	{		
+	~CMemDCLocal()
+	{
 		if (m_bMemDC) {
 			// Copy the offscreen bitmap onto the screen.
 			m_pDC->BitBlt(m_rect.left, m_rect.top, m_rect.Width(), m_rect.Height(),
-				this, m_rect.left, m_rect.top, SRCCOPY);			
-			
+				this, m_rect.left, m_rect.top, SRCCOPY);
+
 			//Swap back the original bitmap.
-			SelectObject(m_oldBitmap);		
+			SelectObject(m_oldBitmap);
 		} else {
 			// All we need to do is replace the DC with an illegal value,
 			// this keeps us from accidently deleting the handles associated with
-			// the CDC that was passed to the constructor.			
+			// the CDC that was passed to the constructor.
 			m_hDC = m_hAttribDC = NULL;
-		}	
+		}
 	}
-	
-	// Allow usage as a pointer	
-	CMemDC* operator->() 
+
+	// Allow usage as a pointer
+	CMemDCLocal* operator->()
 	{
 		return this;
-	}	
+	}
 
-	// Allow usage as a pointer	
-	operator CMemDC*() 
+	// Allow usage as a pointer
+	operator CMemDCLocal*()
 	{
 		return this;
 	}

--- a/SpectrumGraph.cpp
+++ b/SpectrumGraph.cpp
@@ -66,7 +66,7 @@ void CFrequencyGraph::OnPaint()
 	//using either class will get ride of the 
 	//flicker problem that otherwise presents itself...
 	CPaintDC paintdc(this);
-	CMemDC dc(&paintdc,&rct);
+	CMemDCLocal dc(&paintdc,&rct);
 
 // graph
 	if (m_nLength == 0)

--- a/wfgui.vcxproj
+++ b/wfgui.vcxproj
@@ -20,13 +20,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v141</PlatformToolset>
-    <UseOfMfc>Dynamic</UseOfMfc>
+    <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v141</PlatformToolset>
-    <UseOfMfc>Dynamic</UseOfMfc>
+    <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -68,7 +68,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>.\Debug/wfgui.pch</PrecompiledHeaderOutputFile>
@@ -114,7 +114,7 @@
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>


### PR DESCRIPTION
The project is MFC/Win32 (winmm waveIn-based) and can't be compiled on macOS. This adds a windows-latest CI job that installs the MFC/ATL component, builds Release|Win32 via msbuild, and uploads the .exe as a build artifact.