### PR TITLE
Wire up the Save log checkbox

### DIFF
--- a/wfguiDlg.cpp
+++ b/wfguiDlg.cpp
@@ -112,7 +112,7 @@ CWfguiDlg::CWfguiDlg(CWnd* pParent /*=NULL*/)
 	: CDialog(CWfguiDlg::IDD, pParent)
 	, m_radio3(false)
 	, m_max_10_sec(_T(""))
-	, m_log(false)
+	, m_log(FALSE)
 {
 	//{{AFX_DATA_INIT(CWfguiDlg)
 	m_status = _T("");
@@ -150,6 +150,7 @@ void CWfguiDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_FREQ, m_freq_display);
 	DDX_Control(pDX, IDC_RMS, m_RMS_box);
 	DDX_Control(pDX, IDC_LED, m_OK_LED);
+	DDX_Check(pDX, IDC_CHECK1, m_log);
 }
 
 BEGIN_MESSAGE_MAP(CWfguiDlg, CDialog)

--- a/wfguiDlg.h
+++ b/wfguiDlg.h
@@ -109,7 +109,7 @@ public:
 	CEdit m_RMS_box;
 	//CButton
 	CLedButton m_OK_LED;
-	bool m_log;
+	BOOL m_log;
 };
 
 //{{AFX_INSERT_LOCATION}}


### PR DESCRIPTION
Ticking **Save log** currently does nothing — `log.txt` is never created by a binary built from this tree.

## Cause

`m_log` is declared in `wfguiDlg.h` and initialised in the constructor, and the logging code that uses it is present and correct:

```cpp
if(m_log) fp_log = fopen("log.txt","w");                       // OnButton2
if(m_log && (fp_log > 0)) fprintf(fp_log, "%.1f %.4f %.4f\n",  // ProcessHeader
            freq, max_RMS[index_100], max_peak_10);
```

But `m_log` was never bound to `IDC_CHECK1` — no `DDX_Check` entry, no message-map handler. It stays `false` for the lifetime of the dialog, so both branches are unreachable.

`m_savefile` / `IDC_FILTER` ("Save wave") *is* bound, which is why `WF_out.dat` works and `log.txt` does not.

## Fix

Add the missing `DDX_Check`, and widen `m_log` from `bool` to `BOOL` since that is what `DDX_Check` binds to. `OnButton2` already calls `UpdateData(TRUE)` before deciding whether to open the file, so nothing else is needed.

## Why it's worth fixing

Per-second logging across a full cassette is the feature the community values most — it's what the [v8 announcement](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-662483) was about, and it's how you spot a stretched belt or a failing idler. The thread contains a long stretch of users ticking the box, finding no file, and being pointed at folder permissions and VirtualStore instead of a missing binding.

## Testing

Not built locally — no Windows/MFC toolchain to hand. CI builds on pull requests, so this PR exercises it. The change is two declarations and one DDX line, all standard MFC.

Documentation for this lands in #7, which currently describes the non-working checkbox as a known limitation; that note should be dropped once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)