### PR TITLE
Store measured frequency in WF_freq.dat, and stop overwriting captures

### DIFF
--- a/wfguiDlg.cpp
+++ b/wfguiDlg.cpp
@@ -44,7 +44,6 @@ double max_RMS[100];
 double max_peak_10sec[100];
 int index_100, index_max_RMS;
 
-int process_sample(void);
 extern "C" {
 	double process_2nd_order(register double val);
 	double process_flutter(register double val);
@@ -322,9 +321,6 @@ HCURSOR CWfguiDlg::OnQueryDragIcon()
 
 
 
-short error_3150;
-
-
 double freq,err1, err2;
 double nanosec_per_sample;
 double sum_of_squares, sum_of_squares1;
@@ -360,13 +356,6 @@ LRESULT CWfguiDlg::OnMyMessage(WPARAM wParam, LPARAM lParam)
 
 
 double proper_interval = 0.5 * 10e8/3150; // half a period of 3150 sampled
-
-int process_sample(void){
-
-      last_val = this_val;
-
-	  return error_3150;
-}
 
 short input_wav[4410]; // 0.1 sec worth of the wave
 int scope_samples;
@@ -758,9 +747,6 @@ void CWfguiDlg::ProcessHeader(WAVEHDR *pHdr)
 			last_val = this_val;
 
 			if(zero_cross){
-				  error_3150 = (short)(10 * (proper_interval - interval));
-				// for 1% will be 315
-
 		
 				if(first_buffer){
 					good_samples = 0;
@@ -769,9 +755,15 @@ void CWfguiDlg::ProcessHeader(WAVEHDR *pHdr)
 				}
   
 				  
-				if(m_savefile)
-					if(outf > 0)
-						fwrite(&error_3150,2,1,outf);
+				// Store the measured frequency in Hz. interval is the length of
+				// one half period in nanoseconds, so a full cycle is twice that.
+				// One float per zero crossing, i.e. a sample rate of twice the
+				// carrier. Written before any weighting filter is applied, so
+				// the file does not depend on the selection in the UI.
+				if(m_savefile && (outf > 0) && (interval > 0.0)){
+					float freq_sample = (float)(1e9 / (2.0 * interval));
+					fwrite(&freq_sample, sizeof(freq_sample), 1, outf);
+				}
 		
 		
 				err = (proper_interval - interval)   / proper_interval; // in %

--- a/wfguiDlg.cpp
+++ b/wfguiDlg.cpp
@@ -481,6 +481,29 @@ void CWfguiDlg::OnButton1() //STOP
 	
 }
 
+// Never overwrite an existing capture: if the plain name is taken, fall back to
+// name_1, name_2 and so on. A measurement is a tape pass long and cannot be
+// reproduced exactly, so silently truncating the previous run on Start was an
+// easy way to lose one.
+CString CWfguiDlg::MakeUniqueFileName(LPCTSTR lpszBase, LPCTSTR lpszExt)
+{
+	CString csName;
+	int nT1;
+
+	csName.Format("%s%s", lpszBase, lpszExt);
+	if(GetFileAttributes(csName) == INVALID_FILE_ATTRIBUTES)
+		return csName;
+
+	for(nT1 = 1; nT1 < 10000; ++nT1)
+	{
+		csName.Format("%s_%d%s", lpszBase, nT1, lpszExt);
+		if(GetFileAttributes(csName) == INVALID_FILE_ATTRIBUTES)
+			return csName;
+	}
+
+	return csName; // 10000 already in the way, overwrite the last rather than fail
+}
+
 void CWfguiDlg::OnButton2() // START
 {
 	MMRESULT mRes;
@@ -515,11 +538,14 @@ void CWfguiDlg::OnButton2() // START
 	nanosec_per_sample = 10e8 / 44100;
 
 
+	// WF_freq.dat rather than the old WF_out.dat: the contents changed from a
+	// scaled interval error to frequency in Hz, and the file has no header to
+	// tell the two apart.
 	if(m_savefile)
-			outf = fopen("WF_out.dat","wb");
+			outf = fopen(MakeUniqueFileName("WF_freq", ".dat"),"wb");
 
 	if(m_log)
-			fp_log = fopen("log.txt","w");
+			fp_log = fopen(MakeUniqueFileName("log", ".txt"),"w");
 
 	OpenDevice();	
 	PrepareBuffers();

--- a/wfguiDlg.h
+++ b/wfguiDlg.h
@@ -97,6 +97,7 @@ public:
 	WAVEFORMATEX m_stWFEX;
 	CString StoreError(MMRESULT mRes,BOOL bDisplay,LPCTSTR lpszFormat, ...);
 	void OpenDevice();
+	CString MakeUniqueFileName(LPCTSTR lpszBase, LPCTSTR lpszExt);
 	void OnCbnSelchangeDevices();
 	int FillDevices(void);
 	void UnPrepareBuffers(void);


### PR DESCRIPTION
`WF_out.dat` held an implementation detail rather than a measurement:

```c
error_3150 = (short)(10 * (proper_interval - interval));
fwrite(&error_3150, 2, 1, outf);
```

A half-period error, scaled into tenths of a nanosecond. Nothing in the headerless file said so, the unit came from the zero-crossing timer rather than from anything physical, and **the scaling was not trustworthy** — the comment claims `// for 1% will be 315`, but `proper_interval` is 158730 ns at 3150 Hz, so 1% scaled by ten is about 15873. Anyone reading absolute values out of the file was reading them wrong.

## 1. Store frequency in Hz

```c
float freq_sample = (float)(1e9 / (2.0 * interval));
fwrite(&freq_sample, sizeof(freq_sample), 1, outf);
```

`interval` is one half period in nanoseconds, so a full cycle is twice that. The stored quantity is now physical and self-describing — no calibration constant to reconstruct, and a value can be sanity-checked by eye against the nominal 3000 or 3150 Hz.

Float resolution at 3150 Hz is ~0.0004 Hz, orders of magnitude finer than the measurement noise, so nothing is lost.

**Unchanged:** the sample rate (one sample per zero crossing, i.e. twice the carrier), and the position in the chain — still written *before* the weighting filter, so the file stays independent of the UI selection and valid for spectrum analysis whatever weighting is displayed.

## 2. Rename to `WF_freq.dat`

The file is headerless, so once it is on disk nothing distinguishes an old capture from a new one. Keeping the name would leave people importing 16-bit integers as floats, or the reverse, with no indication anything was wrong. A different name makes that mistake impossible rather than merely documented.

| | Before | After |
|---|---|---|
| Name | `WF_out.dat` | `WF_freq.dat` |
| Sample | `short` (2 bytes) | `float` (4 bytes) |
| Quantity | scaled half-period error | frequency, Hz |
| Audacity import | signed 16-bit | 32-bit float |
| Size, 5 min @ 3150 Hz | ~3.7 MB | ~7.4 MB |

## 3. Stop overwriting previous runs

Both output files were opened with a fixed name on every Start, so beginning a second measurement destroyed the first without warning. A measurement takes a full tape pass and cannot be reproduced exactly, which makes this an easy way to lose work — the standing advice on the forum has been to rename the file by hand after every run ([#1](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-662483), [#47](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-775510292)).

`MakeUniqueFileName` falls back to `WF_freq_1.dat`, `WF_freq_2.dat` and so on when the plain name is taken.

**Note this is applied to `log.txt` as well**, slightly beyond the file this PR is named for. The two are written by the same action and it would be odd for one to be preserved and the other quietly replaced — but say the word if you would rather it were only the capture.

## Cleanup

`error_3150` and `process_sample()` fed only the old write and had no other callers anywhere in the tree — they go with it.

## Worth knowing

- Samples now sit around 3150 rather than around zero, so a spectrum analysis has a large DC component. **Remove the DC offset before analysing**, or ignore the zero bin.
- The app does not announce which filename it settled on. With sequential numbering the folder makes it obvious, but I can surface it in the UI if you want it explicit.

## Testing

Not built locally — no Windows/MFC toolchain to hand. CI builds this PR. Worth capturing a file and confirming the values land near nominal before merging; that check is now easy to do by eye, which it was not before.

Documentation for the new format and naming is in #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)