### PR TITLE
Capture to a 32-bit WAV file, and stop overwriting runs

### DIFF
--- a/wfguiDlg.cpp
+++ b/wfguiDlg.cpp
@@ -323,6 +323,7 @@ HCURSOR CWfguiDlg::OnQueryDragIcon()
 
 
 short error_3150;
+int capture_clipped; // a sample hit the 16 bit limit during this run
 
 
 double freq,err1, err2;
@@ -546,6 +547,7 @@ void CWfguiDlg::OnButton2() // START
 	started = 0; // for discarding a few first points
 	peak = 0.0;
 	max_peak = 0.0;
+	capture_clipped = 0;
 	nanosec_per_sample = 10e8 / 44100;
 
 
@@ -750,7 +752,7 @@ void CWfguiDlg::ProcessHeader(WAVEHDR *pHdr)
 			m_OK_LED.Depress(false);
 			return;
 		}
-		m_status = "";
+		m_status = capture_clipped ? "Capture clipped" : "";
 
 		m_OK_LED.Depress(true);
 
@@ -781,8 +783,31 @@ void CWfguiDlg::ProcessHeader(WAVEHDR *pHdr)
 			last_val = this_val;
 
 			if(zero_cross){
-				  error_3150 = (short)(10 * (proper_interval - interval));
-				// for 1% will be 315
+				  // One count is 0.1 ns of half period error, so at 3150 Hz 1%
+				  // is about 15873 counts. An older comment here read "for 1%
+				  // will be 315", which would only be right if the unit were
+				  // tenths of a Hz of frequency deviation rather than of
+				  // half period error.
+				  //
+				  // A short saturates around +/-2% of nominal speed while the
+				  // frequency gate above accepts +/-5%, so a deck running 2-5%
+				  // off used to wrap the cast and fill the capture with values
+				  // that looked like real signal. Clamp instead: a railed
+				  // capture is visibly broken, a wrapped one is not.
+				  {
+					  double scaled = 10.0 * (proper_interval - interval);
+
+					  if(scaled > 32767.0){
+						  scaled = 32767.0;
+						  if(m_savefile)
+							  capture_clipped = 1;
+					  } else if(scaled < -32768.0){
+						  scaled = -32768.0;
+						  if(m_savefile)
+							  capture_clipped = 1;
+					  }
+					  error_3150 = (short)scaled;
+				  }
 
 		
 				if(first_buffer){

--- a/wfguiDlg.cpp
+++ b/wfguiDlg.cpp
@@ -492,6 +492,29 @@ void CWfguiDlg::OnButton1() //STOP
 	
 }
 
+// Never overwrite an existing capture: if the plain name is taken, fall back to
+// name_1, name_2 and so on. A measurement is a tape pass long and cannot be
+// reproduced exactly, so silently truncating the previous run on Start was an
+// easy way to lose one.
+CString CWfguiDlg::MakeUniqueFileName(LPCTSTR lpszBase, LPCTSTR lpszExt)
+{
+	CString csName;
+	int nT1;
+
+	csName.Format("%s%s", lpszBase, lpszExt);
+	if(GetFileAttributes(csName) == INVALID_FILE_ATTRIBUTES)
+		return csName;
+
+	for(nT1 = 1; nT1 < 10000; ++nT1)
+	{
+		csName.Format("%s_%d%s", lpszBase, nT1, lpszExt);
+		if(GetFileAttributes(csName) == INVALID_FILE_ATTRIBUTES)
+			return csName;
+	}
+
+	return csName; // 10000 already in the way, overwrite the last rather than fail
+}
+
 void CWfguiDlg::OnButton2() // START
 {
 	MMRESULT mRes;
@@ -527,10 +550,10 @@ void CWfguiDlg::OnButton2() // START
 
 
 	if(m_savefile)
-			outf = fopen("WF_out.dat","wb");
+			outf = fopen(MakeUniqueFileName("WF_out", ".dat"),"wb");
 
 	if(m_log)
-			fp_log = fopen("log.txt","w");
+			fp_log = fopen(MakeUniqueFileName("log", ".txt"),"w");
 
 	OpenDevice();	
 	PrepareBuffers();

--- a/wfguiDlg.cpp
+++ b/wfguiDlg.cpp
@@ -44,7 +44,6 @@ double max_RMS[100];
 double max_peak_10sec[100];
 int index_100, index_max_RMS;
 
-int process_sample(void);
 extern "C" {
 	double process_2nd_order(register double val);
 	double process_flutter(register double val);
@@ -322,8 +321,74 @@ HCURSOR CWfguiDlg::OnQueryDragIcon()
 
 
 
-short error_3150;
-int capture_clipped; // a sample hit the 16 bit limit during this run
+int capture_sample; // one 32 bit sample of the capture
+int capture_clipped; // a sample saturated during this run
+
+// Canonical 44 byte PCM WAV header. The two size fields are only known once
+// the run ends, so they are written as zero and patched in on close.
+#pragma pack(push, 1)
+struct WF_WAV_HEADER
+{
+	char  riff_id[4];
+	DWORD riff_size;
+	char  wave_id[4];
+	char  fmt_id[4];
+	DWORD fmt_size;
+	WORD  format_tag;
+	WORD  channels;
+	DWORD sample_rate;
+	DWORD byte_rate;
+	WORD  block_align;
+	WORD  bits_per_sample;
+	char  data_id[4];
+	DWORD data_size;
+};
+#pragma pack(pop)
+
+#define WF_WAV_BITS  32
+#define WF_WAV_BYTES (WF_WAV_BITS / 8)
+
+static void WriteWavHeader(FILE *fp, DWORD dwSampleRate)
+{
+	struct WF_WAV_HEADER h;
+
+	memcpy(h.riff_id, "RIFF", 4);
+	memcpy(h.wave_id, "WAVE", 4);
+	memcpy(h.fmt_id,  "fmt ", 4);
+	memcpy(h.data_id, "data", 4);
+
+	h.riff_size       = 0; // patched on close
+	h.fmt_size        = 16;
+	h.format_tag      = 1; // PCM
+	h.channels        = 1;
+	h.sample_rate     = dwSampleRate;
+	h.block_align     = WF_WAV_BYTES;
+	h.byte_rate       = dwSampleRate * WF_WAV_BYTES;
+	h.bits_per_sample = WF_WAV_BITS;
+	h.data_size       = 0; // patched on close
+
+	fwrite(&h, sizeof(h), 1, fp);
+}
+
+// Fill in the sizes now that the length is known, so the file is a valid WAV
+// that any editor will open without being told the rate or the sample width.
+static void PatchWavHeader(FILE *fp)
+{
+	DWORD dwDataSize, dwRiffSize;
+	long lEnd = ftell(fp);
+
+	if(lEnd < (long)sizeof(struct WF_WAV_HEADER))
+		return;
+
+	dwDataSize = (DWORD)(lEnd - sizeof(struct WF_WAV_HEADER));
+	dwRiffSize = (DWORD)(lEnd - 8);
+
+	if(fseek(fp, 4, SEEK_SET) == 0)
+		fwrite(&dwRiffSize, sizeof(dwRiffSize), 1, fp);
+
+	if(fseek(fp, (long)sizeof(struct WF_WAV_HEADER) - 4, SEEK_SET) == 0)
+		fwrite(&dwDataSize, sizeof(dwDataSize), 1, fp);
+}
 
 
 double freq,err1, err2;
@@ -361,13 +426,6 @@ LRESULT CWfguiDlg::OnMyMessage(WPARAM wParam, LPARAM lParam)
 
 
 double proper_interval = 0.5 * 10e8/3150; // half a period of 3150 sampled
-
-int process_sample(void){
-
-      last_val = this_val;
-
-	  return error_3150;
-}
 
 short input_wav[4410]; // 0.1 sec worth of the wave
 int scope_samples;
@@ -472,6 +530,7 @@ void CWfguiDlg::OnButton1() //STOP
 
 	GetDlgItem(IDC_BUTTON2)->EnableWindow(TRUE);
 	if(outf > 0){
+		PatchWavHeader(outf);
 		fclose(outf);
 		outf = NULL;
 	}
@@ -551,8 +610,11 @@ void CWfguiDlg::OnButton2() // START
 	nanosec_per_sample = 10e8 / 44100;
 
 
-	if(m_savefile)
-			outf = fopen(MakeUniqueFileName("WF_out", ".dat"),"wb");
+	if(m_savefile){
+			outf = fopen(MakeUniqueFileName("WF_out", ".wav"),"wb");
+			if(outf > 0)
+				WriteWavHeader(outf, IsDlgButtonChecked(IDC_RADIO5) ? 6000 : 6300);
+	}
 
 	if(m_log)
 			fp_log = fopen(MakeUniqueFileName("log", ".txt"),"w");
@@ -789,24 +851,30 @@ void CWfguiDlg::ProcessHeader(WAVEHDR *pHdr)
 				  // tenths of a Hz of frequency deviation rather than of
 				  // half period error.
 				  //
-				  // A short saturates around +/-2% of nominal speed while the
-				  // frequency gate above accepts +/-5%, so a deck running 2-5%
-				  // off used to wrap the cast and fill the capture with values
-				  // that looked like real signal. Clamp instead: a railed
-				  // capture is visibly broken, a wrapped one is not.
+				  // The scale is unchanged from when this was a short, so a
+				  // capture of an in range deck holds exactly the values it
+				  // always did. 32 bits removes the ceiling: a short saturated
+				  // around +/-2% while the frequency gate above accepts +/-5%,
+				  // so decks running 2-5% off used to wrap the cast and fill
+				  // the file with values that looked like real signal.
+				  //
+				  // The clamp is now only reachable through something
+				  // pathological, such as a long dropout stretching one
+				  // interval, but a railed capture is visibly broken where a
+				  // wrapped one is not.
 				  {
 					  double scaled = 10.0 * (proper_interval - interval);
 
-					  if(scaled > 32767.0){
-						  scaled = 32767.0;
+					  if(scaled > 2147483647.0){
+						  scaled = 2147483647.0;
 						  if(m_savefile)
 							  capture_clipped = 1;
-					  } else if(scaled < -32768.0){
-						  scaled = -32768.0;
+					  } else if(scaled < -2147483648.0){
+						  scaled = -2147483648.0;
 						  if(m_savefile)
 							  capture_clipped = 1;
 					  }
-					  error_3150 = (short)scaled;
+					  capture_sample = (int)scaled;
 				  }
 
 		
@@ -819,7 +887,7 @@ void CWfguiDlg::ProcessHeader(WAVEHDR *pHdr)
 				  
 				if(m_savefile)
 					if(outf > 0)
-						fwrite(&error_3150,2,1,outf);
+						fwrite(&capture_sample,WF_WAV_BYTES,1,outf);
 		
 		
 				err = (proper_interval - interval)   / proper_interval; // in %

--- a/wfguiDlg.h
+++ b/wfguiDlg.h
@@ -97,6 +97,7 @@ public:
 	WAVEFORMATEX m_stWFEX;
 	CString StoreError(MMRESULT mRes,BOOL bDisplay,LPCTSTR lpszFormat, ...);
 	void OpenDevice();
+	CString MakeUniqueFileName(LPCTSTR lpszBase, LPCTSTR lpszExt);
 	void OnCbnSelchangeDevices();
 	int FillDevices(void);
 	void UnPrepareBuffers(void);


### PR DESCRIPTION
Takes the format break once and fixes everything wrong with the capture file together, rather than spending a compatibility break on any one of them.

## 1. Widen the sample — removes the ±2% ceiling

The capture stored `10 * (proper_interval - interval)` in a `short`, saturating at:

| | 3150 Hz | 3000 Hz |
|---|---|---|
| 1% of nominal | ~15873 counts | ~16667 counts |
| **Saturates at** | **±2.06%** | **±1.97%** |

The frequency gate feeding it accepts **±5%**. So decks running 2–5% off metered normally on screen while every sample written to disk wrapped around — a deck 3% fast wrapped to about −17936, reading as a well-behaved 1.1% *slow* deck with plausible modulation on top. Nothing indicated anything was wrong, and this hits exactly the sick transports someone would most want to run a spectrum on.

Now `int`. **The scale is deliberately unchanged** at 0.1 ns per count, so a capture of an in-range deck holds exactly the values it always did and the documented `count ÷ 15873` conversion still applies. Only the ceiling goes away.

## 2. Write a real WAV header — removes the sample-rate trap

The file was headerless. Sample rate and width had to be supplied by hand on import, and **getting the rate wrong silently scales every frequency read off the spectrum** — which is precisely how the rate was misidentified on the forum for four years ([#9](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-662802) landed on 8571 Hz, retracted in [#12](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-692112); settled correctly in [#64](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-775543222)).

A canonical 44-byte PCM header now carries both, so the file opens correctly on a double-click with nothing to configure. The two size fields are written as zero and patched in on close, since the length isn't known when the run starts.

## 3. Rename to `WF_out.wav` — removes the old/new ambiguity

The previous format was headerless, so a reader had no way to tell an old capture from a new one. The extension change makes that mistake impossible rather than merely documented.

## Also

- **The clamp stays**, now at the `int` range. Only reachable through something pathological — a long dropout stretching one interval — but a railed capture is visibly broken where a wrapped one is not. Still reported as `Capture clipped` in the status line.
- **Neither output file overwrites the previous run.** `MakeUniqueFileName` falls back to `WF_out_1.wav`, `WF_out_2.wav` and so on. A measurement takes a full tape pass and cannot be reproduced exactly; the standing advice on the forum has been to rename files by hand after every run ([#1](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-662483), [#47](https://www.tapeheads.net/threads/version-8-of-the-wfgui.55581/post-775510292)). Applied to `log.txt` too, though that half only becomes reachable once #8 merges.
- **Corrected the scaling comment**, which read `// for 1% will be 315`. That would be right for tenths of a Hz of *frequency* deviation; the stored quantity is tenths of a nanosecond of *half-period* error, where 1% is about 15873 — off by a factor of 50.
- **`process_sample()` removed.** Dead, never called from anywhere, and existed only to return the variable this change replaces.

## Migration

Captures from older builds keep working: they are `WF_out.dat`, headerless, signed 16-bit, and still import with the manual settings. **The count-to-percent conversion is identical** — the scale did not change, only the width and the container. Documented in #7.

## Testing

Not built locally — no Windows/MFC toolchain to hand; CI builds this PR.

Worth checking on the bench before merging:
- a capture opens directly in Audacity at the right rate, with no import dialog
- the file is a valid WAV after **Stop** (the sizes are patched at close, so a run killed without pressing Stop will leave them zero — most tools cope, some won't)
- values still convert to roughly what the meter showed

🤖 Generated with [Claude Code](https://claude.com/claude-code)